### PR TITLE
Import pylsl in try-except

### DIFF
--- a/app/nubrain/experiment/__init__.py
+++ b/app/nubrain/experiment/__init__.py
@@ -1,1 +1,8 @@
-from . import data, global_config, load_config, main, randomize_conditions
+from . import data, global_config, load_config, randomize_conditions
+
+# Wrap the main import in try, so that the other modules can be imported without
+# dependency on pylsl (e.g. when using global_config during preprocessing).
+try:
+    from . import main
+except Exception as e:
+    print(f"Failed to import nubrain main model: {e}")

--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nubrain"
-version = "0.1.18"
+version = "0.1.19"
 description = "NuBrain connect"
 authors = [{ name = "nuBrain Team", email = "hello@nubrain.io" }]
 requires-python = ">=3.10"


### PR DESCRIPTION
Import pylsl in try-except (so that the other modules can be imported without dependency on pylsl).